### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
-skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,./external
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,26 @@
+# Source: https://github.com/per1234/.github/blob/main/workflow-templates/spell-check.md
+name: Spell Check
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 :floppy_disk: `l3xz_io`
 =======================
 [![Build Status](https://github.com/107-systems/l3xz_io/actions/workflows/ros2.yml/badge.svg)](https://github.com/107-systems/l3xz_io/actions/workflows/ros2.yml)
+[![Spell Check status](https://github.com/107-systems/l3xz_io/actions/workflows/spell-check.yml/badge.svg)](https://github.com/107-systems/l3xz_io/actions/workflows/spell-check.yml)
 
 L3X-Z base robot control IO package (ROS).
 

--- a/scripts/setup_slcan.sh
+++ b/scripts/setup_slcan.sh
@@ -9,7 +9,7 @@ Interface indexes will be assigned automatically in ascending order, i.e., the
 first device will be mapped to slcan0, second to slcan1, and so on.
 Each added option affects only the interfaces that follow it,
 which means that options must be properly ordered (see examples below).
-This tool requires superuser priveleges.
+This tool requires superuser privileges.
 
 The package 'can-utils' must be installed. On Debian/Ubuntu-based systems it
 can be installed via APT: apt-get install can-utils

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -302,7 +302,7 @@ int main(int argc, char **argv) try
   };
 
   /* This map contains the angle offsets of all the sensors
-   * angles as reported by the leg controllers. At initialisation
+   * angles as reported by the leg controllers. At initialization
    * these are zero and are then set during the calibration
    * state.
    **/


### PR DESCRIPTION
On every push, pull request, and periodically, use the codespell-project/actions-codespell action to check for commonly
misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the ignore-words-list field
of ./.codespellrc. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore
list. The ignore list is comma-separated with no spaces.